### PR TITLE
feat: Account creation API, UI, and frontend-backend alignment

### DIFF
--- a/frontend/src/app/core/models/account.model.ts
+++ b/frontend/src/app/core/models/account.model.ts
@@ -9,3 +9,8 @@ export interface AccountsResponse {
   accounts: Account[];
   totalCount: number;
 }
+
+export interface CreateAccountRequest {
+  name: string;
+  broker: string;
+}

--- a/frontend/src/app/core/services/account.service.ts
+++ b/frontend/src/app/core/services/account.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { AccountsResponse } from '../models';
+import { Account, AccountsResponse, CreateAccountRequest } from '../models';
 import { API_BASE_URL } from './api.config';
 
 @Injectable({
@@ -13,5 +13,9 @@ export class AccountService {
 
   listAccounts(): Observable<AccountsResponse> {
     return this.http.get<AccountsResponse>(`${this.apiUrl}/accounts`);
+  }
+
+  createAccount(request: CreateAccountRequest): Observable<Account> {
+    return this.http.post<Account>(`${this.apiUrl}/accounts`, request);
   }
 }

--- a/frontend/src/app/features/positions/position-entry/position-entry.component.html
+++ b/frontend/src/app/features/positions/position-entry/position-entry.component.html
@@ -19,14 +19,6 @@
         }
       </div>
     </p-card>
-  } @else if (accounts().length === 0) {
-    <p-card>
-      <div class="empty-state">
-        <i class="pi pi-exclamation-circle empty-icon"></i>
-        <p>No accounts available. Please create an account first.</p>
-        <p-button label="Back to Portfolio" icon="pi pi-arrow-left" severity="secondary" (onClick)="goBack()" />
-      </div>
-    </p-card>
   } @else {
     <p-card>
       <form [formGroup]="form" (ngSubmit)="onSubmit()">
@@ -91,26 +83,36 @@
 
           <div class="field">
             <label for="accountId">Account *</label>
-            <p-select
-              id="accountId"
-              formControlName="accountId"
-              [options]="accounts()"
-              optionLabel="name"
-              optionValue="id"
-              placeholder="Select an account"
-              styleClass="w-full"
-              [class.ng-invalid]="hasFieldError('accountId')"
-              [class.ng-dirty]="form.get('accountId')?.touched"
-            >
-              <ng-template pTemplate="selectedItem" let-account>
-                @if (account) {
+            <div class="account-select-row">
+              <p-select
+                id="accountId"
+                formControlName="accountId"
+                [options]="accounts()"
+                optionLabel="name"
+                optionValue="id"
+                placeholder="Select an account"
+                styleClass="w-full"
+                [class.ng-invalid]="hasFieldError('accountId')"
+                [class.ng-dirty]="form.get('accountId')?.touched"
+              >
+                <ng-template pTemplate="selectedItem" let-account>
+                  @if (account) {
+                    {{ account.name }} ({{ account.broker }})
+                  }
+                </ng-template>
+                <ng-template pTemplate="item" let-account>
                   {{ account.name }} ({{ account.broker }})
-                }
-              </ng-template>
-              <ng-template pTemplate="item" let-account>
-                {{ account.name }} ({{ account.broker }})
-              </ng-template>
-            </p-select>
+                </ng-template>
+              </p-select>
+              <p-button
+                icon="pi pi-plus"
+                [rounded]="true"
+                [outlined]="true"
+                severity="secondary"
+                (onClick)="openAccountDialog()"
+                pTooltip="Create new account"
+              />
+            </div>
             @if (hasFieldError('accountId')) {
               <small class="p-error">{{ getFieldError('accountId') }}</small>
             }
@@ -174,3 +176,29 @@
     </p-card>
   }
 </div>
+
+<p-dialog
+  header="Create Account"
+  [(visible)]="showAccountDialog"
+  [modal]="true"
+  [style]="{ width: '400px' }"
+  [closable]="true"
+>
+  @if (accountDialogError()) {
+    <p-message severity="error" [text]="accountDialogError()!" styleClass="mb-3 w-full" />
+  }
+  <form [formGroup]="accountForm">
+    <div class="field">
+      <label for="accountName">Account Name *</label>
+      <input pInputText id="accountName" formControlName="name" placeholder="e.g., XTB IKE" class="w-full" />
+    </div>
+    <div class="field">
+      <label for="accountBroker">Broker *</label>
+      <input pInputText id="accountBroker" formControlName="broker" placeholder="e.g., XTB" class="w-full" />
+    </div>
+  </form>
+  <ng-template pTemplate="footer">
+    <p-button label="Cancel" severity="secondary" [text]="true" (onClick)="showAccountDialog.set(false)" />
+    <p-button label="Create" icon="pi pi-check" (onClick)="submitAccountDialog()" [loading]="accountDialogLoading()" />
+  </ng-template>
+</p-dialog>

--- a/frontend/src/app/features/positions/position-entry/position-entry.component.scss
+++ b/frontend/src/app/features/positions/position-entry/position-entry.component.scss
@@ -24,23 +24,13 @@
   gap: 0.5rem;
 }
 
-.empty-state {
+.account-select-row {
   display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: 3rem;
-  text-align: center;
-  color: var(--text-color-secondary);
+  gap: 0.5rem;
+  align-items: flex-start;
 
-  .empty-icon {
-    font-size: 3rem;
-    margin-bottom: 1rem;
-    color: var(--orange-500);
-  }
-
-  p {
-    margin-bottom: 1rem;
+  p-select {
+    flex: 1;
   }
 }
 

--- a/frontend/src/app/features/positions/position-entry/position-entry.component.ts
+++ b/frontend/src/app/features/positions/position-entry/position-entry.component.ts
@@ -11,8 +11,10 @@ import { InputNumberModule } from 'primeng/inputnumber';
 import { MessageModule } from 'primeng/message';
 import { SkeletonModule } from 'primeng/skeleton';
 import { FloatLabelModule } from 'primeng/floatlabel';
+import { DialogModule } from 'primeng/dialog';
+import { TooltipModule } from 'primeng/tooltip';
 import { PositionService, AccountService } from '../../../core/services';
-import { Account, InstrumentType, ApiError, ValidationError } from '../../../core/models';
+import { Account, CreateAccountRequest, InstrumentType, ApiError, ValidationError } from '../../../core/models';
 
 @Component({
   selector: 'app-position-entry',
@@ -27,7 +29,9 @@ import { Account, InstrumentType, ApiError, ValidationError } from '../../../cor
     InputNumberModule,
     MessageModule,
     SkeletonModule,
-    FloatLabelModule
+    FloatLabelModule,
+    DialogModule,
+    TooltipModule
   ],
   templateUrl: './position-entry.component.html',
   styleUrl: './position-entry.component.scss'
@@ -40,11 +44,16 @@ export class PositionEntryComponent implements OnInit {
   private readonly destroyRef = inject(DestroyRef);
 
   form!: FormGroup;
+  accountForm!: FormGroup;
   accounts = signal<Account[]>([]);
   loading = signal(false);
   loadingAccounts = signal(true);
   error = signal<string | null>(null);
   fieldErrors = signal<Map<string, string>>(new Map());
+
+  showAccountDialog = signal(false);
+  accountDialogLoading = signal(false);
+  accountDialogError = signal<string | null>(null);
 
   instrumentTypes: { value: InstrumentType; label: string }[] = [
     { value: 'STOCK', label: 'Stock' },
@@ -53,6 +62,7 @@ export class PositionEntryComponent implements OnInit {
 
   ngOnInit(): void {
     this.initForm();
+    this.initAccountForm();
     this.loadAccounts();
   }
 
@@ -64,6 +74,13 @@ export class PositionEntryComponent implements OnInit {
       accountId: [null, [Validators.required]],
       quantity: [null, [Validators.required, Validators.min(0.00000001)]],
       averageCost: [null, [Validators.required, Validators.min(0.0001)]]
+    });
+  }
+
+  private initAccountForm(): void {
+    this.accountForm = this.fb.group({
+      name: ['', [Validators.required, Validators.maxLength(255)]],
+      broker: ['', [Validators.required, Validators.maxLength(255)]]
     });
   }
 
@@ -87,6 +104,39 @@ export class PositionEntryComponent implements OnInit {
 
   goBack(): void {
     this.router.navigate(['/portfolio']);
+  }
+
+  openAccountDialog(): void {
+    this.accountForm.reset();
+    this.accountDialogError.set(null);
+    this.showAccountDialog.set(true);
+  }
+
+  submitAccountDialog(): void {
+    if (this.accountForm.invalid) {
+      this.accountForm.markAllAsTouched();
+      return;
+    }
+
+    this.accountDialogLoading.set(true);
+    this.accountDialogError.set(null);
+
+    const request: CreateAccountRequest = this.accountForm.value;
+
+    this.accountService.createAccount(request)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (newAccount) => {
+          this.accounts.update(current => [...current, newAccount]);
+          this.form.patchValue({ accountId: newAccount.id });
+          this.accountDialogLoading.set(false);
+          this.showAccountDialog.set(false);
+        },
+        error: (err: ApiError) => {
+          this.accountDialogLoading.set(false);
+          this.accountDialogError.set(err.message);
+        }
+      });
   }
 
   onSubmit(): void {

--- a/src/main/java/com/investments/tracker/application/dto/request/CreateAccountRequest.java
+++ b/src/main/java/com/investments/tracker/application/dto/request/CreateAccountRequest.java
@@ -1,0 +1,14 @@
+package com.investments.tracker.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Request to create a new brokerage account.
+ */
+public record CreateAccountRequest(
+        @NotBlank(message = "Account name is required")
+        String name,
+
+        @NotBlank(message = "Broker name is required")
+        String broker) {
+}

--- a/src/main/java/com/investments/tracker/application/usecase/AccountCommandUseCase.java
+++ b/src/main/java/com/investments/tracker/application/usecase/AccountCommandUseCase.java
@@ -1,0 +1,21 @@
+package com.investments.tracker.application.usecase;
+
+import com.investments.tracker.domain.model.Account;
+import com.investments.tracker.domain.model.value.AccountName;
+import com.investments.tracker.domain.model.value.BrokerName;
+
+/**
+ * Use case for account commands (create).
+ */
+public interface AccountCommandUseCase {
+
+    /**
+     * Creates a new brokerage account.
+     *
+     * @param name the account name
+     * @param brokerName the broker name
+     * @return the created account
+     * @throws com.investments.tracker.application.exception.ResourceAlreadyExistsException if account name already exists
+     */
+    Account createAccount(AccountName name, BrokerName brokerName);
+}

--- a/src/main/java/com/investments/tracker/application/usecase/AccountCommandUseCaseService.java
+++ b/src/main/java/com/investments/tracker/application/usecase/AccountCommandUseCaseService.java
@@ -1,0 +1,37 @@
+package com.investments.tracker.application.usecase;
+
+import com.investments.tracker.application.exception.ResourceAlreadyExistsException;
+import com.investments.tracker.domain.model.Account;
+import com.investments.tracker.domain.model.value.AccountName;
+import com.investments.tracker.domain.model.value.BrokerName;
+import com.investments.tracker.domain.repository.AccountRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
+
+/**
+ * Implementation of account command use case.
+ */
+@Service
+@Transactional
+public class AccountCommandUseCaseService implements AccountCommandUseCase {
+
+    private final AccountRepository accountRepository;
+
+    public AccountCommandUseCaseService(AccountRepository accountRepository) {
+        this.accountRepository = accountRepository;
+    }
+
+    @Override
+    public Account createAccount(AccountName name, BrokerName brokerName) {
+        Objects.requireNonNull(name, "name cannot be null");
+        Objects.requireNonNull(brokerName, "brokerName cannot be null");
+
+        if (accountRepository.findByName(name).isPresent()) {
+            throw new ResourceAlreadyExistsException("Account", "name", name.value());
+        }
+
+        return accountRepository.create(name, brokerName);
+    }
+}

--- a/src/main/java/com/investments/tracker/domain/repository/AccountRepository.java
+++ b/src/main/java/com/investments/tracker/domain/repository/AccountRepository.java
@@ -2,6 +2,8 @@ package com.investments.tracker.domain.repository;
 
 import com.investments.tracker.domain.model.Account;
 import com.investments.tracker.domain.model.value.AccountId;
+import com.investments.tracker.domain.model.value.AccountName;
+import com.investments.tracker.domain.model.value.BrokerName;
 
 import java.util.Collection;
 import java.util.Optional;
@@ -58,4 +60,21 @@ public interface AccountRepository {
      * @return the count
      */
     long count();
+
+    /**
+     * Finds an account by its name.
+     *
+     * @param name the account name
+     * @return optional account
+     */
+    Optional<Account> findByName(AccountName name);
+
+    /**
+     * Creates a new account with a database-generated ID.
+     *
+     * @param name the account name
+     * @param brokerName the broker name
+     * @return the created account with generated ID
+     */
+    Account create(AccountName name, BrokerName brokerName);
 }

--- a/src/main/java/com/investments/tracker/infrastructure/persistence/adapter/AccountRepositoryAdapter.java
+++ b/src/main/java/com/investments/tracker/infrastructure/persistence/adapter/AccountRepositoryAdapter.java
@@ -2,6 +2,8 @@ package com.investments.tracker.infrastructure.persistence.adapter;
 
 import com.investments.tracker.domain.model.Account;
 import com.investments.tracker.domain.model.value.AccountId;
+import com.investments.tracker.domain.model.value.AccountName;
+import com.investments.tracker.domain.model.value.BrokerName;
 import com.investments.tracker.domain.repository.AccountRepository;
 import com.investments.tracker.infrastructure.persistence.entity.AccountJpaEntity;
 import com.investments.tracker.infrastructure.persistence.mapper.AccountPersistenceMapper;
@@ -58,5 +60,18 @@ public class AccountRepositoryAdapter implements AccountRepository {
     @Override
     public long count() {
         return jpaRepository.count();
+    }
+
+    @Override
+    public Optional<Account> findByName(AccountName name) {
+        return jpaRepository.findByName(name.value())
+                .map(mapper::toDomain);
+    }
+
+    @Override
+    public Account create(AccountName name, BrokerName brokerName) {
+        AccountJpaEntity entity = mapper.toNewEntity(name, brokerName);
+        AccountJpaEntity saved = jpaRepository.save(entity);
+        return mapper.toDomain(saved);
     }
 }

--- a/src/main/java/com/investments/tracker/infrastructure/persistence/mapper/AccountPersistenceMapper.java
+++ b/src/main/java/com/investments/tracker/infrastructure/persistence/mapper/AccountPersistenceMapper.java
@@ -47,4 +47,21 @@ public class AccountPersistenceMapper {
         entity.setAccountType(AccountType.NORMAL);
         return entity;
     }
+
+    /**
+     * Creates a new JPA entity without an ID (for database-generated IDs).
+     *
+     * @param name the account name
+     * @param brokerName the broker name
+     * @return the JPA entity without ID set
+     */
+    public AccountJpaEntity toNewEntity(AccountName name, BrokerName brokerName) {
+        Objects.requireNonNull(name, "name cannot be null");
+        Objects.requireNonNull(brokerName, "brokerName cannot be null");
+        AccountJpaEntity entity = new AccountJpaEntity();
+        entity.setName(name.value());
+        entity.setBrokerName(brokerName.value());
+        entity.setAccountType(AccountType.NORMAL);
+        return entity;
+    }
 }

--- a/src/main/java/com/investments/tracker/infrastructure/persistence/repository/AccountJpaRepository.java
+++ b/src/main/java/com/investments/tracker/infrastructure/persistence/repository/AccountJpaRepository.java
@@ -3,5 +3,9 @@ package com.investments.tracker.infrastructure.persistence.repository;
 import com.investments.tracker.infrastructure.persistence.entity.AccountJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface AccountJpaRepository extends JpaRepository<AccountJpaEntity, Long> {
+
+    Optional<AccountJpaEntity> findByName(String name);
 }

--- a/src/main/java/com/investments/tracker/infrastructure/web/controller/AccountController.java
+++ b/src/main/java/com/investments/tracker/infrastructure/web/controller/AccountController.java
@@ -1,14 +1,23 @@
 package com.investments.tracker.infrastructure.web.controller;
 
 import com.investments.tracker.application.dto.mapper.AccountMapper;
+import com.investments.tracker.application.dto.request.CreateAccountRequest;
 import com.investments.tracker.application.dto.response.AccountDTO;
 import com.investments.tracker.application.dto.response.AccountListResponse;
+import com.investments.tracker.application.usecase.AccountCommandUseCase;
 import com.investments.tracker.application.usecase.AccountQueryUseCase;
 import com.investments.tracker.domain.model.Account;
 import com.investments.tracker.domain.model.value.AccountId;
+import com.investments.tracker.domain.model.value.AccountName;
+import com.investments.tracker.domain.model.value.BrokerName;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Collection;
@@ -22,10 +31,15 @@ import java.util.List;
 public class AccountController {
 
     private final AccountQueryUseCase accountQueryUseCase;
+    private final AccountCommandUseCase accountCommandUseCase;
     private final AccountMapper accountMapper;
 
-    public AccountController(AccountQueryUseCase accountQueryUseCase, AccountMapper accountMapper) {
+    public AccountController(
+            AccountQueryUseCase accountQueryUseCase,
+            AccountCommandUseCase accountCommandUseCase,
+            AccountMapper accountMapper) {
         this.accountQueryUseCase = accountQueryUseCase;
+        this.accountCommandUseCase = accountCommandUseCase;
         this.accountMapper = accountMapper;
     }
 
@@ -52,6 +66,21 @@ public class AccountController {
     @GetMapping("/{id}")
     public AccountDTO getAccount(@PathVariable Long id) {
         Account account = accountQueryUseCase.getAccount(new AccountId(id));
+        return accountMapper.toDTO(account);
+    }
+
+    /**
+     * Creates a new brokerage account.
+     *
+     * @param request the create account request
+     * @return the created account DTO
+     */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public AccountDTO createAccount(@Valid @RequestBody CreateAccountRequest request) {
+        Account account = accountCommandUseCase.createAccount(
+                new AccountName(request.name()),
+                new BrokerName(request.broker()));
         return accountMapper.toDTO(account);
     }
 }

--- a/src/main/resources/db/migration/V2__add_account_name_unique.sql
+++ b/src/main/resources/db/migration/V2__add_account_name_unique.sql
@@ -1,0 +1,2 @@
+-- Add unique constraint on account name to prevent duplicates (FR-075)
+ALTER TABLE accounts ADD CONSTRAINT accounts_name_unique UNIQUE (name);

--- a/src/test/java/com/investments/tracker/application/usecase/AccountCommandUseCaseServiceTest.java
+++ b/src/test/java/com/investments/tracker/application/usecase/AccountCommandUseCaseServiceTest.java
@@ -1,0 +1,98 @@
+package com.investments.tracker.application.usecase;
+
+import com.investments.tracker.application.exception.ResourceAlreadyExistsException;
+import com.investments.tracker.domain.model.Account;
+import com.investments.tracker.domain.model.value.AccountId;
+import com.investments.tracker.domain.model.value.AccountName;
+import com.investments.tracker.domain.model.value.BrokerName;
+import com.investments.tracker.domain.repository.AccountRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@DisplayName("AccountCommandUseCaseService")
+@ExtendWith(MockitoExtension.class)
+class AccountCommandUseCaseServiceTest {
+
+    @Mock
+    private AccountRepository accountRepository;
+
+    private AccountCommandUseCaseService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new AccountCommandUseCaseService(accountRepository);
+    }
+
+    @Nested
+    @DisplayName("createAccount")
+    class CreateAccount {
+
+        @Test
+        @DisplayName("should create account when name is unique")
+        void shouldCreateAccountWhenNameIsUnique() {
+            // Given
+            AccountName name = new AccountName("XTB");
+            BrokerName broker = new BrokerName("XTB");
+            Account expected = new Account(new AccountId(1L), name, broker);
+
+            when(accountRepository.findByName(name)).thenReturn(Optional.empty());
+            when(accountRepository.create(name, broker)).thenReturn(expected);
+
+            // When
+            Account result = service.createAccount(name, broker);
+
+            // Then
+            assertThat(result.id().value()).isEqualTo(1L);
+            assertThat(result.name().value()).isEqualTo("XTB");
+            assertThat(result.brokerName().value()).isEqualTo("XTB");
+            verify(accountRepository).create(name, broker);
+        }
+
+        @Test
+        @DisplayName("should throw ResourceAlreadyExistsException when name already exists")
+        void shouldThrowWhenNameAlreadyExists() {
+            // Given
+            AccountName name = new AccountName("XTB");
+            BrokerName broker = new BrokerName("XTB");
+            Account existing = new Account(new AccountId(1L), name, broker);
+
+            when(accountRepository.findByName(name)).thenReturn(Optional.of(existing));
+
+            // When/Then
+            assertThatThrownBy(() -> service.createAccount(name, broker))
+                    .isInstanceOf(ResourceAlreadyExistsException.class)
+                    .hasMessageContaining("Account")
+                    .hasMessageContaining("XTB");
+
+            verify(accountRepository, never()).create(any(), any());
+        }
+
+        @Test
+        @DisplayName("should throw NullPointerException when name is null")
+        void shouldThrowWhenNameIsNull() {
+            assertThatThrownBy(() -> service.createAccount(null, new BrokerName("XTB")))
+                    .isInstanceOf(NullPointerException.class);
+        }
+
+        @Test
+        @DisplayName("should throw NullPointerException when brokerName is null")
+        void shouldThrowWhenBrokerNameIsNull() {
+            assertThatThrownBy(() -> service.createAccount(new AccountName("XTB"), null))
+                    .isInstanceOf(NullPointerException.class);
+        }
+    }
+}

--- a/src/test/java/com/investments/tracker/cucumber/steps/AccountSteps.java
+++ b/src/test/java/com/investments/tracker/cucumber/steps/AccountSteps.java
@@ -1,0 +1,156 @@
+package com.investments.tracker.cucumber.steps;
+
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Cucumber step definitions for Account Management feature.
+ *
+ * @see <a href="requirements/functional/features/account-management.feature">Account Management Feature</a>
+ */
+public class AccountSteps {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    private ResponseEntity<Map> response;
+    private long accountCountBefore;
+
+    // --- Given Steps ---
+
+    @Given("I want to add a new brokerage account")
+    public void iWantToAddANewBrokerageAccount() {
+        accountCountBefore = countAccounts();
+    }
+
+    @Given("an account named {string} already exists")
+    public void anAccountNamedAlreadyExists(String accountName) {
+        CucumberTestHelper.ensureAccountExists(jdbcTemplate, accountName);
+        accountCountBefore = countAccounts();
+    }
+
+    @Given("no accounts exist in the system")
+    public void noAccountsExistInTheSystem() {
+        accountCountBefore = 0;
+    }
+
+    // --- When Steps ---
+
+    @When("I enter the following account data:")
+    public void iEnterTheFollowingAccountData(DataTable dataTable) {
+        Map<String, String> data = dataTable.asMap();
+        Map<String, String> body = new HashMap<>();
+        body.put("name", data.get("Name"));
+        body.put("broker", data.get("Broker"));
+        response = postAccount(body);
+    }
+
+    @When("I try to create an account without a name")
+    public void iTryToCreateAnAccountWithoutAName() {
+        Map<String, String> body = new HashMap<>();
+        body.put("broker", "Some Broker");
+        response = postAccount(body);
+    }
+
+    @When("I try to create an account without a broker name")
+    public void iTryToCreateAnAccountWithoutABrokerName() {
+        Map<String, String> body = new HashMap<>();
+        body.put("name", "Some Account");
+        response = postAccount(body);
+    }
+
+    @When("I try to create another account named {string}")
+    public void iTryToCreateAnotherAccountNamed(String accountName) {
+        Map<String, String> body = new HashMap<>();
+        body.put("name", accountName);
+        body.put("broker", "Different Broker");
+        response = postAccount(body);
+    }
+
+    @When("I create a new account {string} with broker {string} during position entry")
+    public void iCreateANewAccountWithBrokerDuringPositionEntry(String name, String broker) {
+        Map<String, String> body = new HashMap<>();
+        body.put("name", name);
+        body.put("broker", broker);
+        response = postAccount(body);
+        assertThat(response.getStatusCode().value()).isEqualTo(201);
+    }
+
+    // --- Then Steps ---
+
+    @Then("a new account {string} should be created")
+    public void aNewAccountShouldBeCreated(String accountName) {
+        assertThat(response.getStatusCode().value()).isEqualTo(201);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().get("name").toString()).isEqualTo(accountName);
+    }
+
+    @Then("the account should be available for position assignment")
+    public void theAccountShouldBeAvailableForPositionAssignment() {
+        ResponseEntity<Map> listResponse = restTemplate.getForEntity(
+                "http://localhost:" + port + "/api/v1/accounts", Map.class);
+        assertThat(listResponse.getStatusCode().is2xxSuccessful()).isTrue();
+        List<?> accounts = (List<?>) listResponse.getBody().get("accounts");
+        assertThat(accounts).isNotEmpty();
+    }
+
+    @Then("I should see an account error {string}")
+    public void iShouldSeeAnAccountError(String expectedMessage) {
+        assertThat(response.getStatusCode().is4xxClientError())
+                .as("Expected 4xx error but got: " + response.getStatusCode())
+                .isTrue();
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().toString())
+                .containsIgnoringCase(expectedMessage.replace("\"", ""));
+    }
+
+    @Then("no account should be created")
+    public void noAccountShouldBeCreated() {
+        assertThat(countAccounts()).isEqualTo(accountCountBefore);
+    }
+
+    @Then("the position should be assigned to account {string}")
+    public void thePositionShouldBeAssignedToAccount(String accountName) {
+        List<Long> ids = jdbcTemplate.queryForList(
+                "SELECT id FROM accounts WHERE name = ?", Long.class, accountName);
+        assertThat(ids).isNotEmpty();
+    }
+
+    // --- Helper Methods ---
+
+    private ResponseEntity<Map> postAccount(Map<String, String> body) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<Map<String, String>> request = new HttpEntity<>(body, headers);
+        return restTemplate.postForEntity(
+                "http://localhost:" + port + "/api/v1/accounts",
+                request, Map.class);
+    }
+
+    private long countAccounts() {
+        Long count = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM accounts", Long.class);
+        return count != null ? count : 0;
+    }
+}


### PR DESCRIPTION
## Summary
- Align frontend-backend API contracts (DTOs, error handling, field naming)
- Fix empty portfolio message and remove unused `Account.createdAt`
- Add account management requirements (FR-073 to FR-076) with Cucumber scenarios
- Implement `POST /api/v1/accounts` with validation, duplicate detection (409 Conflict), and Flyway migration for unique constraint
- Add inline account creation dialog in position entry form (FR-076)
- Includes unit tests and Cucumber step definitions

## Note
Known bug in `PositionRepositoryAdapter.save()` is intentionally left unfixed for investigation — creates detached entity instead of updating managed entity, causing `NonUniqueObjectException` when adding holdings to existing positions.

## Test plan
- [x] Unit tests pass (`AccountCommandUseCaseServiceTest`)
- [x] Cucumber integration tests pass (account-management.feature)
- [x] Angular frontend compiles
- [x] Full build passes (`./gradlew clean build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)